### PR TITLE
redirect publish endpoint to draft-annotations

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -55,7 +55,7 @@ sub vcl_recv {
             set req.backend_hint = dynBackend.backend("cm-generic-concept-transformer");
     }
     elif (req.url ~ "^\/draft-annotations\/content\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/annotations\/publish.*$") {
-            set req.backend_hint = dynBackend.backend("annotations-publisher");
+            set req.backend_hint = dynBackend.backend("draft-annotations-api");
     }
     elif (req.url ~ "^\/draft-annotations\/content.*$") {
             set req.backend_hint = dynBackend.backend("draft-annotations-api");


### PR DESCRIPTION
# Description

## What

As we implemented the annotations publish logic in the draft annotations. We have to redirect it to the correct service in order to deprecate the annotations-publisher.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-5510

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
